### PR TITLE
chore: Switch to kind ClusterKeycloak in case if add-ons approach use

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -97,6 +97,9 @@ A Helm chart for EDP Install
 | sso.ingress.ingressClassName | string | `""` | Defines which ingress controller will implement the resource, e.g. nginx |
 | sso.ingress.pathType | string | `"Prefix"` | Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific` |
 | sso.ingress.tls | list | `[]` | Ingress TLS configuration |
+| sso.keycloakOperatorResources.createKeycloakCR | bool | `true` |  |
+| sso.keycloakOperatorResources.kind | string | `"Keycloak"` |  |
+| sso.keycloakOperatorResources.name | string | `"main"` |  |
 | sso.keycloakUrl | string | `"https://keycloak.example.com"` | Keycloak URL. |
 | sso.nodeSelector | object | `{}` | Node labels for pod assignment |
 | sso.ssoRealmName | string | `"broker"` | Defines Keycloak sso realm name that is used as the Identity Provider (IdP) realm |

--- a/deploy-templates/templates/external-secrets/externalsecret-keycloak.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-keycloak.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets }}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets .Values.sso.keycloakOperatorResources.createKeycloakCR }}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageEDPInstallSecretsName }}
 ---

--- a/deploy-templates/templates/keycloak/keycloak.yaml
+++ b/deploy-templates/templates/keycloak/keycloak.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.sso.enabled -}}
+{{- if and .Values.sso.enabled .Values.sso.keycloakOperatorResources.createKeycloakCR }}
 apiVersion: v1.edp.epam.com/v1
 kind: Keycloak
 metadata:
-  name: "main"
+  name: {{ .Values.sso.keycloakOperatorResources.name }}
   labels:
     {{- include "edp-install.labels" . | nindent 4 }}
 spec:

--- a/deploy-templates/templates/keycloak/realm.yaml
+++ b/deploy-templates/templates/keycloak/realm.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "edp-install.labels" . | nindent 4 }}
 spec:
-  keycloakOwner: main
+  keycloakRef:
+    kind: {{ .Values.sso.keycloakOperatorResources.kind }}
+    name: {{ .Values.sso.keycloakOperatorResources.name }}
   realmName: {{ default .Release.Namespace .Values.sso.realmName }}
   ssoRealmEnabled: true
   ssoRealmName: {{ .Values.sso.ssoRealmName }}
@@ -21,4 +23,4 @@ spec:
     realmRoles:
       - developer
   {{- end}}
-{{ end }}
+{{- end }}

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -452,6 +452,19 @@ edp-tekton:
 sso:
   # -- Install OAuth2-proxy and Keycloak CRs as a part of EDP deployment.
   enabled: false
+
+  keycloakOperatorResources:
+    # Set to false if using the add-ons approach (refer to https://github.com/epam/edp-cluster-add-ons)
+    # for EDP installation and if the extension-oidc is already installed.
+    # This prevents the creation of an additional Keycloak resource and secret.
+    # The 'kind' and 'name' must be specified in case of using an existing Keycloak/ClusterKeycloak resource.
+    # Create kind: Keycloak as a part of chart installation
+    createKeycloakCR: true
+    # Can be Keycloak or ClusterKeycloak.
+    kind: Keycloak
+    # Name of kind: Keycloak/ClusterKeycloak CR.
+    name: main
+
   # -- Defines the Keycloak realm name, which by default is named after the namespace where EDP is deployed.
   # realmName: edp
   # -- Defines Keycloak sso realm name that is used as the Identity Provider (IdP) realm


### PR DESCRIPTION
Description
This pull request introduces conditional logic and configuration updates for the Keycloak deployment templates within the deploy-templates directory. The aim is to refine the deployment process based on the integration of external secrets and the presence of an OpenID Connect (OIDC) extension. The updates ensure that only the necessary Keycloak resources are created and managed, preventing redundant configurations when the OIDC extension is already in place.

Key Changes:
Added conditions to check the state of .Values.externalSecrets.enabled and .Values.sso.addonsExtensionsOIDC to optimize secret management.
Revised references to keycloakRef to align with the new conditional logic, ensuring that Keycloak resources are referenced correctly.
Expanded the values.yaml to include configurations for the addonsExtensionsOIDC flag, which dictates the creation of additional Keycloak resources based on the presence of an OIDC extension.
These modifications will provide greater flexibility in deploying Keycloak within environments that use external secrets management and have the OIDC extension installed.

Type of change
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
 
How Has This Been Tested?
 - [x] Tests are included to verify the logic of the conditional statements.
 - [x] Deployment has been tested in an environment where the OIDC extension is present to ensure no additional - [ ] - 
 - [x]  Keycloak resources are created unnecessarily.

Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits
