### PR TITLE
feat: Align chart for ingress TLS configuration(#210)

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -49,11 +49,13 @@ A Helm chart for EDP Install
 | edp-headlamp.enabled | bool | `true` |  |
 | edp-headlamp.ingress.annotations | object | `{}` | Annotations for Ingress resource |
 | edp-headlamp.ingress.enabled | bool | `true` | Enable external endpoint access. Default Ingress/Route host pattern: portal-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }} |
+| edp-headlamp.ingress.host | string | `""` | If not specified the pattern "portal-[namespace].[global DNS wildcard]" will create a URL like "portal-namespace.example.com" |
 | edp-headlamp.ingress.tls | list | `[]` | Ingress TLS configuration |
 | edp-tekton.dashboard.enabled | bool | `true` | https://epam.github.io/edp-install/operator-guide/oauth2-proxy/ |
 | edp-tekton.dashboard.ingress.annotations | object | `{}` | Annotations for Ingress resource |
 | edp-tekton.dashboard.ingress.enabled | bool | `true` | Enable external endpoint access. Default Ingress/Route host pattern: tekton-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }} |
-| edp-tekton.dashboard.ingress.tls | list | `[]` | Uncomment it to enable tekton-dashboard OIDC on EKS cluster nginx.ingress.kubernetes.io/auth-signin: 'https://<oauth-ingress-host>/oauth2/start?rd=https://$host$request_uri' nginx.ingress.kubernetes.io/auth-url: 'http://oauth2-proxy.edp.svc.cluster.local:8080/oauth2/auth' |
+| edp-tekton.dashboard.ingress.host | string | `""` | If not specified the pattern "tekton-[namespace].[global DNS wildcard]" will create a URL like "tekton-namespace.example.com" |
+| edp-tekton.dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
 | edp-tekton.dashboard.openshift_proxy | object | `{"enabled":false}` | https://epam.github.io/edp-install/operator-guide/oauth2-proxy/?h=#enable-oauth2-proxy-on-tekton-dashboard |
 | edp-tekton.dashboard.openshift_proxy.enabled | bool | `false` | Enable oauth-proxy to include authorization layer on tekton-dashboard. Default: flase |
 | edp-tekton.dashboard.readOnly | bool | `false` | Define mode for Tekton Dashboard. Enable/disaable capability to create/modify/remove Tekton objects via Tekton Dashboard. Default: false. |
@@ -94,6 +96,7 @@ A Helm chart for EDP Install
 | sso.image.tag | string | `"v7.4.0"` | OAuth2-proxy image tag |
 | sso.ingress.annotations | object | `{}` | Additional ingress annotations |
 | sso.ingress.enabled | bool | `true` | Enable ingress controller resource |
+| sso.ingress.host | string | `""` | If not specified the pattern "oauth-[namespace].[global DNS wildcard]" will create a URL like "oauth-namespace.example.com" |
 | sso.ingress.ingressClassName | string | `""` | Defines which ingress controller will implement the resource, e.g. nginx |
 | sso.ingress.pathType | string | `"Prefix"` | Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific` |
 | sso.ingress.tls | list | `[]` | Ingress TLS configuration |

--- a/deploy-templates/templates/oauth2-proxy/ingress.yaml
+++ b/deploy-templates/templates/oauth2-proxy/ingress.yaml
@@ -19,12 +19,24 @@ spec:
   {{- if and $ingressSupportsIngressClassName .Values.sso.ingress.ingressClassName }}
   ingressClassName: {{ .Values.sso.ingress.ingressClassName }}
   {{- end }}
-{{- if .Values.sso.ingress.tls }}
+  {{- if .Values.sso.ingress.tls }}
   tls:
-{{ tpl (toYaml .Values.sso.ingress.tls) $ | indent 4 }}
-{{- end }}
+    {{- range .Values.sso.ingress.tls }}
+    - hosts:
+        {{- if .hosts }}
+        {{- toYaml .hosts | nindent 8 }}
+        {{- else }}
+        - {{ include "oauth2_proxy.Url" $ }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
+    {{- if .Values.sso.ingress.host }}
+    - host: {{ .Values.sso.ingress.host }}
+    {{- else}}
     - host: {{ include "oauth2_proxy.Url" . }}
+    {{- end}}
       http:
         paths:
           - path: /

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -251,6 +251,11 @@ gerrit-operator:
   #     # --  For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   #     # --  See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   #     # ingressClassName: nginx
+  #     # -- Defines the base URL for the gerrit
+  #     # -- If not specified the pattern "gerrit-[namespace].[global DNS wildcard]" will create a URL like "gerrit-namespace.example.com"
+  #     host: ""
+  #     # -- Hostname(s) for the Ingress resource
+  #     # -- Ingress TLS configuration
   #     tls: []
   #     #  - secretName: chart-example-tls
   #     #    hosts:
@@ -266,6 +271,9 @@ edp-headlamp:
       {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    # -- Defines the base URL for the portal.
+    # -- If not specified the pattern "portal-[namespace].[global DNS wildcard]" will create a URL like "portal-namespace.example.com"
+    host: ""
     # -- Hostname(s) for the Ingress resource
     # -- Ingress TLS configuration
     tls: []
@@ -333,6 +341,11 @@ edp-tekton:
         # -- Uncomment it to enable tekton-dashboard OIDC on EKS cluster
         # nginx.ingress.kubernetes.io/auth-signin: 'https://<oauth-ingress-host>/oauth2/start?rd=https://$host$request_uri'
         # nginx.ingress.kubernetes.io/auth-url: 'http://oauth2-proxy.edp.svc.cluster.local:8080/oauth2/auth'
+      # -- Defines the base URL for the tekton-dashboard.
+      # -- If not specified the pattern "tekton-[namespace].[global DNS wildcard]" will create a URL like "tekton-namespace.example.com"
+      host: ""
+      # -- Hostname(s) for the Ingress resource
+      # -- Ingress TLS configuration
       tls: []
       #  - secretName: chart-example-tls
       #    hosts:
@@ -526,6 +539,9 @@ sso:
     # Ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
     # -- Defines which ingress controller will implement the resource, e.g. nginx
     ingressClassName: ""
+    # -- Defines the base URL for the OAuth2 proxy.
+    # -- If not specified the pattern "oauth-[namespace].[global DNS wildcard]" will create a URL like "oauth-namespace.example.com"
+    host: ""
     # -- Ingress TLS configuration
     tls: []
     #  - secretName: chart-example-tls


### PR DESCRIPTION
## Description
This pull request introduces updates to the oauth2-proxy Ingress template and the associated values.yaml to enhance flexibility and configuration options for ingress resources. The main changes include the capability to specify ingressClassName directly in values.yaml for Kubernetes clusters that support this feature, as well as improvements in handling TLS configurations and host settings for the Ingress resource.

The changes allow users to:

Specify a base URL for the OAuth2 proxy through a new host parameter. If not set, the system generates a default URL based on the pattern "oauth-[namespace].[global DNS wildcard]".
Configure TLS more dynamically, with the option to define hosts and secretName directly in values.yaml.
These improvements aim to make the Helm chart more adaptable to various deployment environments and requirements.

Fixes #210

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

The changes were tested in a Kubernetes cluster by deploying the updated Helm chart and verifying:

The Ingress resource correctly adopts the specified ingressClassName.
The generated host URL correctly reflects the host parameter when specified, and falls back to the default pattern when not.
TLS settings are correctly applied to the Ingress, with the ability to specify custom hosts and secret names.
Testing steps included:

Deploying the Helm chart with various values.yaml configurations.
Checking the generated Ingress resource to verify the applied settings.
Testing connectivity to the deployed OAuth2-proxy service through the defined Ingress to ensure proper routing and TLS configuration.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits
