### PR TITLE
fix: Add rbac for portal widgets(#237)

### DIFF
--- a/deploy-templates/templates/rbac/role_developer.yaml
+++ b/deploy-templates/templates/rbac/role_developer.yaml
@@ -19,3 +19,9 @@ rules:
       - pipelineruns
     verbs:
       - create
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - secrets


### PR DESCRIPTION
Description
This pull request adds RBAC for portal widgets to ensure that the edp-developer role can display widgets in the portal codebase while preventing access to secrets.

Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

How Has This Been Tested?

The changes were tested by reviewing the RBAC policy to ensure that the edp-developer role has permissions to get widgets but not to access secrets. The following tests were conducted:

Verification that widgets are displayed for the edp-developer role.
Confirmation that secrets are not not displayed in the portal by the edp-developer role.

Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits