### PR TITLE
chore: Align keycloakUrl example value for portal chart(#264)

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -39,12 +39,12 @@ A Helm chart for EDP Install
 | cd-pipeline-operator.tenancyEngine | string | `"none"` | Defines the type of the tenant engine that can be "none", "kiosk" or "capsule"; for Stages with external cluster tenancyEngine will be ignored. Default: none |
 | codebase-operator.enabled | bool | `true` |  |
 | edp-headlamp.config.baseURL | string | `""` | base url path at which headlamp should run |
-| edp-headlamp.config.oidc | object | `{"clientID":"","clientSecretKey":"clientSecret","clientSecretName":"keycloak-client-headlamp-secret","enabled":false,"issuerRealm":"","keycloakUrl":"https://keycloak.example.com","scopes":""}` | For detailed instructions, refer to: https://epam.github.io/edp-install/operator-guide/configure-keycloak-oidc-eks/, https://epam.github.io/edp-install/operator-guide/headlamp-oidc/ |
+| edp-headlamp.config.oidc | object | `{"clientID":"","clientSecretKey":"clientSecret","clientSecretName":"keycloak-client-headlamp-secret","enabled":false,"issuerRealm":"","keycloakUrl":"https://keycloak.example.com/auth","scopes":""}` | For detailed instructions, refer to: https://epam.github.io/edp-install/operator-guide/configure-keycloak-oidc-eks/, https://epam.github.io/edp-install/operator-guide/headlamp-oidc/ |
 | edp-headlamp.config.oidc.clientID | string | `""` | OIDC client ID |
 | edp-headlamp.config.oidc.clientSecretKey | string | `"clientSecret"` | OIDC client secret key |
 | edp-headlamp.config.oidc.clientSecretName | string | `"keycloak-client-headlamp-secret"` | OIDC client secret name |
 | edp-headlamp.config.oidc.issuerRealm | string | `""` | OIDC issuer realm |
-| edp-headlamp.config.oidc.keycloakUrl | string | `"https://keycloak.example.com"` | Keycloak URL |
+| edp-headlamp.config.oidc.keycloakUrl | string | `"https://keycloak.example.com/auth"` | Keycloak URL |
 | edp-headlamp.config.oidc.scopes | string | `""` | OIDC scopes to be used |
 | edp-headlamp.enabled | bool | `true` |  |
 | edp-headlamp.ingress.annotations | object | `{}` | Annotations for Ingress resource |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -291,7 +291,7 @@ edp-headlamp:
       # Enable OIDC integration. Default: false
       enabled: false
       # -- Keycloak URL
-      keycloakUrl: "https://keycloak.example.com"
+      keycloakUrl: "https://keycloak.example.com/auth"
       # -- OIDC client ID
       clientID: ""
       # -- OIDC client secret name


### PR DESCRIPTION
Pull Request Template
Description
This change aligns the keycloakUrl example value within the portal chart to include the /auth path by default. It ensures that the example configuration reflects a more common Keycloak deployment scenario, making it easier for new users to configure OIDC integration correctly on their first attempt.

Type of change

- [x] New feature (non-breaking change which adds functionality)

How Has This Been Tested?

Manual testing with a Keycloak instance to ensure that the updated keycloakUrl with the /auth path is correctly utilized in OIDC authentication scenarios.
Reviewed the Helm chart deployment process to confirm that the changes do not affect the deployment and interaction with the OIDC provider.

Checklist:
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in areas that might be difficult to understand.
- [ ] I have made corresponding changes to the documentation, updating the keycloakUrl example.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] This Pull Request contains a single commit, squashed from multiple commits addressing the same issue.
Additional context
This adjustment is a direct response to feedback from users attempting to configure OIDC for the first time. By providing a keycloakUrl example that includes the /auth path, we aim to reduce configuration errors and improve the user experience.