### PR TITLE
chore: Disable Tekton dashboard deployments(#276)

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -50,7 +50,7 @@ A Helm chart for KubeRocketCI Platform
 | edp-headlamp.ingress.annotations | object | `{}` | Annotations for Ingress resource |
 | edp-headlamp.ingress.enabled | bool | `true` | Enable external endpoint access. Default Ingress/Route host pattern: portal-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }} |
 | edp-headlamp.ingress.tls | list | `[]` | Ingress TLS configuration |
-| edp-tekton.dashboard.enabled | bool | `true` | https://docs.kuberocketci.io/docs/operator-guide/auth/oauth2-proxy |
+| edp-tekton.dashboard.enabled | bool | `false` | https://docs.kuberocketci.io/docs/operator-guide/auth/oauth2-proxy |
 | edp-tekton.dashboard.ingress.annotations | object | `{}` | Annotations for Ingress resource |
 | edp-tekton.dashboard.ingress.enabled | bool | `true` | Enable external endpoint access. Default Ingress/Route host pattern: tekton-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }} |
 | edp-tekton.dashboard.ingress.tls | list | `[]` | Uncomment it to enable tekton-dashboard OIDC on EKS cluster nginx.ingress.kubernetes.io/auth-signin: 'https://<oauth-ingress-host>/oauth2/start?rd=https://$host$request_uri' nginx.ingress.kubernetes.io/auth-url: 'http://oauth2-proxy.edp.svc.cluster.local:8080/oauth2/auth' |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -316,12 +316,12 @@ edp-tekton:
     # url: http://tekton-cache:8080
 
   dashboard:
-    # -- Deploy Tekton Dashboard as a part of pipeline library when true. Default: true
+    # -- Deploy Tekton Dashboard as a part of pipeline library when true. Default: false
     # -- WARNING: Default deployment of the dashboard does not involve any proxy and may be accessible to the public.
     # -- To enable proxy protect use openshift_proxy or sso.enabled sections.
     # -- More details:
     # -- https://docs.kuberocketci.io/docs/operator-guide/auth/oauth2-proxy
-    enabled: true
+    enabled: false
 
     # -- Define mode for Tekton Dashboard. Enable/disaable capability to create/modify/remove Tekton objects via Tekton Dashboard. Default: false.
     readOnly: false


### PR DESCRIPTION
Description
We are updating the deployment configuration for CI environments to disable the deployment of the Tekton dashboard. This is due to the introduction of the KubeRocketCI (KRCI) Portal, which serves as an alternative to the Tekton dashboard, making it redundant in our workflow.

Type of change

- [x] New feature (non-breaking change which adds functionality)

How Has This Been Tested?

The configuration changes were applied to a test CI environment to ensure they do not negatively affect the build process or the functionality provided by the KRCI Portal.
A series of automated tests were run to confirm that all CI pipelines and related functionality remain operational.

Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Pull Request contains a single squashed commit
