### PR TITLE
chore: Migrate External Secrets resources to v1 API version

### DIFF
--- a/deploy-templates/templates/_helpers.tpl
+++ b/deploy-templates/templates/_helpers.tpl
@@ -75,3 +75,16 @@ Create the name of the secretstore to use
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for External Secrets
+*/}}
+{{- define "app.externalSecrets.apiVersion" -}}
+  {{- if .Capabilities.APIVersions.Has "external-secrets.io/v1" -}}
+    {{- print "external-secrets.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" -}}
+    {{- print "external-secrets.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "external-secrets.io/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/deploy-templates/templates/external-secrets/externalsecret-ci-argocd.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-ci-argocd.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets -}}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageEDPInstallSecretsName }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: ExternalSecret
 metadata:
   name: ci-argocd

--- a/deploy-templates/templates/external-secrets/externalsecret-ci-codemie.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-ci-codemie.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets .Values.externalSecrets.manageCodemieSecretsName -}}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageCodemieSecretsName }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: ExternalSecret
 metadata:
   name: ci-codemie

--- a/deploy-templates/templates/external-secrets/externalsecret-ci-defectdojo.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-ci-defectdojo.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets }}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageEDPInstallSecretsName }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: ExternalSecret
 metadata:
   name: ci-defectdojo

--- a/deploy-templates/templates/external-secrets/externalsecret-ci-dependency-track.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-ci-dependency-track.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets }}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageEDPInstallSecretsName }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: ExternalSecret
 metadata:
   name: ci-dependency-track

--- a/deploy-templates/templates/external-secrets/externalsecret-ci-jira.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-ci-jira.yaml
@@ -2,7 +2,7 @@
 {{- $credentialName := index .Values "codebase-operator" "jira" "credentialName" }}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageEDPInstallSecretsName }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: ExternalSecret
 metadata:
   name: {{ $credentialName }}

--- a/deploy-templates/templates/external-secrets/externalsecret-ci-nexus.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-ci-nexus.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets -}}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageEDPInstallSecretsName }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: ExternalSecret
 metadata:
   name: ci-nexus

--- a/deploy-templates/templates/external-secrets/externalsecret-ci-sonarqube.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-ci-sonarqube.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets -}}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageEDPInstallSecretsName }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: ExternalSecret
 metadata:
   name: ci-sonarqube

--- a/deploy-templates/templates/external-secrets/externalsecret-edp-headlamp.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-edp-headlamp.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets }}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageEDPInstallSecretsName }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: ExternalSecret
 metadata:
   name: keycloak-client-headlamp-secret

--- a/deploy-templates/templates/external-secrets/externalsecret-gitprovider.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-gitprovider.yaml
@@ -5,7 +5,7 @@
 {{- $gitProvider := . }}
 {{- if not (eq "gerrit" $gitProvider) }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" $ }}
 kind: ExternalSecret
 metadata:
   name: ci-{{ $gitProvider }}

--- a/deploy-templates/templates/external-secrets/externalsecret-kaniko.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-kaniko.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets (eq .Values.global.dockerRegistry.type "harbor" "dockerhub" "nexus" "ghcr") }}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageEDPInstallSecretsName }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: ExternalSecret
 metadata:
   name: kaniko-docker-config

--- a/deploy-templates/templates/external-secrets/externalsecret-regcred.yaml
+++ b/deploy-templates/templates/external-secrets/externalsecret-regcred.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.externalSecrets.enabled .Values.externalSecrets.manageEDPInstallSecrets (eq .Values.global.dockerRegistry.type "harbor" "dockerhub" "nexus" "ghcr") }}
 {{- $secretStore := include "edp-install.secretStoreName" . }}
 {{- $awsSecretName := .Values.externalSecrets.manageEDPInstallSecretsName }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: ExternalSecret
 metadata:
   name: regcred

--- a/deploy-templates/templates/external-secrets/secretstore-aws.yaml
+++ b/deploy-templates/templates/external-secrets/secretstore-aws.yaml
@@ -4,7 +4,7 @@
 {{- if not (has .Values.externalSecrets.secretProvider.aws.service $validAwsProviders) }}
 {{- fail "Unsupported AWS Secret Provider, expected ParameterStore or SecretsManager" }}
 {{- end }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: SecretStore
 metadata:
   name: {{ include "edp-install.secretStoreName" . }}

--- a/deploy-templates/templates/external-secrets/secretstore-generic.yaml
+++ b/deploy-templates/templates/external-secrets/secretstore-generic.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.externalSecrets.enabled }}
 {{- if eq .Values.externalSecrets.type "generic" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ include "app.externalSecrets.apiVersion" . }}
 kind: SecretStore
 metadata:
   name: {{ include "edp-install.secretStoreName" . }}

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -676,7 +676,7 @@ extraQuickLinks: {}
 
 # -- Array of extra K8s manifests to deploy
 extraObjects: []
-  # - apiVersion: external-secrets.io/v1beta1
+  # - apiVersion: external-secrets.io/v1
   #   kind: ExternalSecret
   #   metadata:
   #     name: example-secret-1
@@ -694,7 +694,7 @@ extraObjects: []
   #       kind: SecretStore
   #       name: example-parameterstore
   # - |
-  #       apiVersion: external-secrets.io/v1beta1
+  #       apiVersion: external-secrets.io/v1
   #       kind: ExternalSecret
   #       metadata:
   #         name: example-secret-2


### PR DESCRIPTION
# Pull Request

## Description
Migrate `External Secrets` resources to `v1` API version.

Fixes #486 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.