### PR TITLE
 EPMDEDP-16728: feat: Add missing Tekton and Tekton Triggers permissi…

### DIFF
--- a/deploy-templates/templates/rbac/role_developer.yaml
+++ b/deploy-templates/templates/rbac/role_developer.yaml
@@ -17,29 +17,69 @@ rules:
       - tekton.dev
     resources:
       - pipelineruns
+      - taskruns
     verbs:
+      - get
+      - list
+      - watch
+      - create
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelines
+      - tasks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
       - create
       - update
       - delete
+  - apiGroups:
+      - triggers.tekton.dev
+    resources:
+      - interceptors
+      - triggertemplates
+      - eventlisteners
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - triggers.tekton.dev
+    resources:
+      - triggerbindings
+      - triggers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
   - apiGroups:
       - ''
     resources:
       - configmaps
     verbs:
       - '*'
-  - verbs:
-      - update
-    apiGroups:
+  - apiGroups:
       - edp.epam.com
     resources:
       - approvaltasks
-  - verbs:
-      - '*'
-    apiGroups:
+    verbs:
+      - update
+  - apiGroups:
       - v2.edp.epam.com
     resources:
       - codebasebranches
-  - verbs:
+    verbs:
+      - '*'
+  - apiGroups:
+      - v2.edp.epam.com
+    resources:
+      - stages
+      - cdpipelines
+    verbs:
       - get
       - list
       - watch
@@ -47,8 +87,3 @@ rules:
       - update
       - patch
       - delete
-    apiGroups:
-      - v2.edp.epam.com
-    resources:
-      - stages
-      - cdpipelines


### PR DESCRIPTION
## Description
Add missing Tekton and Tekton Triggers permissions to developer role

  Expand RBAC permissions to enable developers to work with Tekton pipelines and
  Tekton Triggers for CI/CD automation.

  Changes:
  - Split tekton.dev permissions: pipelineruns/taskruns are read+create only (lifecycle managed by platform); pipelines/tasks allow full mutation
  - Add Tekton Triggers resources: interceptors/triggertemplates read-only, triggerbindings/triggers allow read+create for trigger workflows
  - Fix YAML key ordering (apiGroups/resources/verbs) for consistency

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.