### PR TITLE
EPMDEDP-17098: feat: Add clusterName configuration parameter for krci…

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -83,6 +83,7 @@ A Helm chart for KubeRocketCI Platform
 | global.apiClusterEndpoint | string | `""` | API Сluster Endpoint configuration for static kubeconfig generation |
 | global.apiGatewayUrl | string | `""` | API Gateway URL configuration for Widget Functionality |
 | global.availableClusters | string | `""` | Define the list of available remote clusters to deploy applications. Example: "cluster1, cluster2, cluster3" |
+| global.clusterName | string | `""` | Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...). Must match krci-portal configEnv.DEFAULT_CLUSTER_NAME. If left empty, falls back to the first segment of dnsWildCard |
 | global.developerGroupName | string | `""` |  |
 | global.dnsWildCard | string | `nil` | a cluster DNS wildcard name |
 | global.dockerRegistry.awsRegion | string | `""` | Defines the geographic area where the (AWS) Elastic Container Registry repository is hosted (optional). E.g. "eu-central-1". Mandatory if 'global.dockerRegistry.type=ecr' for kaniko build-task. Ref: https://github.com/epam/edp-tekton/blob/release/0.10/charts/pipelines-library/templates/tasks/kaniko.yaml#L73 |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -12,6 +12,9 @@ global:
   # The 'apiGatewayUrl' should be set to the external URL of the KrakenD API Gateway exposed via Ingress.
   # Example: https://api.domain.example.com
   # By default, this value is left empty, and widgets are disabled.
+  # -- Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...).
+  # Must match krci-portal configEnv.DEFAULT_CLUSTER_NAME. If left empty, falls back to the first segment of dnsWildCard
+  clusterName: ""
   # -- API Gateway URL configuration for Widget Functionality
   apiGatewayUrl: ""
   # The API endpoint for Kubernetes cluster. This should be the cluster's server endpoint


### PR DESCRIPTION
…-portal pipeline URLs

The new edp-tekton pipelineUrlParam helper requires a clusterName value to construct krci-portal pipeline URLs (/c/<clusterName>/...). This parameter allows users to explicitly set the cluster name, with automatic fallback to the first segment of dnsWildCard if left empty. Must match the krci-portal configEnv.DEFAULT_CLUSTER_NAME setting for proper integration.

# Pull Request Template

## Description
Please include a summary of the change and why it is needed.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.