### PR TITLE
EPMDEDP-17098: feat: Add clusterName configuration to edp-tekton values

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -52,6 +52,7 @@ A Helm chart for KubeRocketCI Platform
 | edp-headlamp.ingress.annotations | object | `{}` | Annotations for Ingress resource |
 | edp-headlamp.ingress.enabled | bool | `true` | Enable external endpoint access. Default Ingress/Route host pattern: portal-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }} |
 | edp-headlamp.ingress.tls | list | `[]` | Ingress TLS configuration |
+| edp-tekton.clusterName | string | `""` | Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...). Must match krci-portal.configEnv.DEFAULT_CLUSTER_NAME. If left empty, falls back to the first segment of global.dnsWildCard. |
 | edp-tekton.enabled | bool | `true` |  |
 | edp-tekton.gitServers | object | `{}` |  |
 | edp-tekton.grafana | object | `{"enabled":false}` | https://docs.kuberocketci.io/docs/operator-guide/ci/tekton-monitoring |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -382,6 +382,10 @@ edp-headlamp:
 edp-tekton:
   enabled: true
 
+  # -- Cluster name used to construct the krci-portal pipeline URL (/c/<clusterName>/...).
+  # Must match krci-portal.configEnv.DEFAULT_CLUSTER_NAME. If left empty, falls back to the first segment of global.dnsWildCard.
+  clusterName: ""
+
   pipelines:
     image:
       # -- Registry for tekton pipelines images. Default: docker.io


### PR DESCRIPTION
Adds clusterName parameter to edp-tekton section in values.yaml to allow explicit configuration of the cluster name used in krci-portal pipeline URL construction. Falls back to the first segment of global.dnsWildCard if not specified, and must match krci-portal.configEnv.DEFAULT_CLUSTER_NAME.

# Pull Request Template

## Description
Please include a summary of the change and why it is needed.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.