### PR TITLE
EPMDEDP-17177: feat: Propagate Envoy Gateway configuration to dependent charts

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -41,6 +41,7 @@ A Helm chart for KubeRocketCI Platform
 | cd-pipeline-operator.serviceAccount.annotations | object | `{}` |  |
 | cd-pipeline-operator.tenancyEngine | string | `"none"` | Defines the type of the tenant engine that can be "none", "kiosk" or "capsule"; for Stages with external cluster tenancyEngine will be ignored. Default: none |
 | codebase-operator.enabled | bool | `true` |  |
+| codebase-operator.ingressController | string | `"nginx"` | Ingress controller for the GitServer EventListener webhook: "nginx" (Ingress) or "envoy" (Gateway API HTTPRoute). When set to "envoy", the operator attaches an HTTPRoute to global.gatewayApi.{gatewayName,gatewayNamespace}. |
 | edp-headlamp.config.baseURL | string | `""` | base url path at which headlamp should run |
 | edp-headlamp.config.oidc | object | `{"clientID":"","clientSecretKey":"clientSecret","clientSecretName":"keycloak-client-headlamp-secret","enabled":false,"issuerUrl":"","scopes":""}` | For detailed instructions, refer to: https://docs.kuberocketci.io/docs/operator-guide/auth/configure-keycloak-oidc-eks, https://docs.kuberocketci.io/docs/operator-guide/auth/ui-portal-oidc |
 | edp-headlamp.config.oidc.clientID | string | `""` | OIDC client ID |
@@ -91,6 +92,8 @@ A Helm chart for KubeRocketCI Platform
 | global.dockerRegistry.space | string | `""` | Defines project name. |
 | global.dockerRegistry.type | string | `""` | Defines type of registry. One of `ecr`, `harbor`, `dockerhub`, `openshift`, `nexus` or `ghcr`. 'openshift' registry is available only in case if platform is deployed on the OpenShift cluster and the variable global.platform is set to 'openshift'. |
 | global.dockerRegistry.url | string | `""` | Defines registry endpoint URL. |
+| global.gatewayApi.gatewayName | string | `"main-gateway"` | Name of the parent Gateway resource |
+| global.gatewayApi.gatewayNamespace | string | `"envoy-gateway-system"` | Namespace of the parent Gateway resource |
 | global.gitProviders | list | `["github"]` | Can be gerrit, github, gitlab or bitbucket. Default: github |
 | global.platform | string | `"kubernetes"` | platform type that can be "kubernetes" or "openshift" |
 | global.viewerGroupName | string | `""` |  |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -38,6 +38,24 @@ global:
     # - gerrit
     # - bitbucket
 
+  # Gateway API parent Gateway that EventListener/webhook HTTPRoutes attach to.
+  # Shared by edp-tekton and codebase-operator; the Gateway itself must already exist
+  # (provisioned by Envoy Gateway, e.g. via edp-cluster-add-ons).
+  #
+  # Switching from nginx Ingress to Envoy Gateway (safe, per-gitServer, reversible):
+  #   1. Keep the default here (main-gateway/envoy-gateway-system) or point at your Gateway.
+  #   2. Per gitServer, set edp-tekton.gitServers.<name>.eventListener.httproute.enabled=true.
+  #      The Ingress stays rendered as a fallback, so the webhook keeps working during cutover.
+  #   3. Set codebase-operator.ingressController=envoy so the operator registers new webhooks
+  #      against the HTTPRoute host instead of the Ingress host.
+  #   4. Once traffic is confirmed on Envoy, set eventListener.ingress.enabled=false to drop nginx.
+  # These values are ignored while ingressController=nginx and no gitServer enables httproute.
+  gatewayApi:
+    # -- Name of the parent Gateway resource
+    gatewayName: "main-gateway"
+    # -- Namespace of the parent Gateway resource
+    gatewayNamespace: "envoy-gateway-system"
+
   # Define the Image Registry that will be used in Pipelines.
   # This section is optional, and users can configure the registry within the KubeRocketCI Portal user interface.
   # Ref: https://docs.kuberocketci.io/docs/user-guide/manage-container-registries#add-container-registry
@@ -162,6 +180,9 @@ marketplaceTemplates:
 
 codebase-operator:
   enabled: true
+  # -- Ingress controller for the GitServer EventListener webhook: "nginx" (Ingress) or "envoy" (Gateway API HTTPRoute).
+  # When set to "envoy", the operator attaches an HTTPRoute to global.gatewayApi.{gatewayName,gatewayNamespace}.
+  ingressController: "nginx"
   # image:
   #   repository: epamedp/codebase-operator
   #   tag:
@@ -527,6 +548,11 @@ edp-tekton:
   #         annotations: {}
   #         # -- Ingress TLS configuration
   #         tls: []
+  #       httproute:
+  #         # -- Enable Gateway API HTTPRoute (Envoy Gateway) for this EventListener
+  #         enabled: false
+  #         # -- HTTPRoute annotations
+  #         annotations: {}
 
   #   my-gitlab:
   #     gitProvider: gitlab
@@ -561,6 +587,11 @@ edp-tekton:
   #         annotations: {}
   #         # -- Ingress TLS configuration
   #         tls: []
+  #       httproute:
+  #         # -- Enable Gateway API HTTPRoute (Envoy Gateway) for this EventListener
+  #         enabled: false
+  #         # -- HTTPRoute annotations
+  #         annotations: {}
 
   #   my-gerrit:
   #     gitProvider: gerrit
@@ -599,6 +630,11 @@ edp-tekton:
   #         annotations: {}
   #         # -- Ingress TLS configuration
   #         tls: []
+  #       httproute:
+  #         # -- Enable Gateway API HTTPRoute (Envoy Gateway) for this EventListener
+  #         enabled: false
+  #         # -- HTTPRoute annotations
+  #         annotations: {}
 
   #   my-bitbucket:
   #     gitProvider: bitbucket
@@ -633,6 +669,11 @@ edp-tekton:
   #         annotations: {}
   #         # -- Ingress TLS configuration
   #         tls: []
+  #       httproute:
+  #         # -- Enable Gateway API HTTPRoute (Envoy Gateway) for this EventListener
+  #         enabled: false
+  #         # -- HTTPRoute annotations
+  #         annotations: {}
 
 # -- Define platform Quick Links, more details: https://github.com/epam/edp-codebase-operator/
 # Example: "https://argocd.example.com"


### PR DESCRIPTION


- Add global.gatewayApi (gatewayName/gatewayNamespace) so the shared Gateway is passed down to edp-tekton and codebase-operator via Helm global values
- Add codebase-operator.ingressController toggle to switch the GitServer webhook from nginx Ingress to Envoy Gateway HTTPRoute
- Document the per-gitServer eventListener.httproute option and a reversible, zero-downtime nginx -> Envoy migration procedure in values.yaml
- Defaults keep everything on nginx, so existing installs are unaffected

