### PR TITLE
EPMDEDP-17178: feat: Add Envoy Gateway resources to the view RBAC agg…

### DIFF
--- a/deploy-templates/templates/rbac/role_edp_aggregate_view.yaml
+++ b/deploy-templates/templates/rbac/role_edp_aggregate_view.yaml
@@ -80,3 +80,33 @@ rules:
       - list
       - get
       - watch
+  # Gateway API (Envoy Gateway migration): read access so viewers/developers can see
+  # routing objects (Gateways, HTTPRoutes) in the Portal Networking view.
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+      - referencegrants
+    verbs:
+      - get
+      - list
+      - watch
+  # Envoy Gateway CRDs: read access to the full resource family (proxies + policies)
+  # surfaced by the Portal Networking view.
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - backends
+      - backendtrafficpolicies
+      - clienttrafficpolicies
+      - envoyextensionpolicies
+      - envoypatchpolicies
+      - envoyproxies
+      - httproutefilters
+      - securitypolicies
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
## Description

Align the platform RBAC model with Envoy Gateway resources.

As part of the nginx-ingress -> Envoy Gateway migration, KRCI components now
create Gateway API objects (HTTPRoutes, Gateways) and the Portal surfaces them in
the Deployments -> Networking view. However the platform view RBAC did not cover
these API groups, so only cluster-admins could see them — viewers and developers
got an empty view / RBAC error.

This PR extends the `edp-aggregate-view` ClusterRole (aggregated into the built-in
`view` role via `rbac.authorization.k8s.io/aggregate-to-view: "true"`) with
read-only access (`get`/`list`/`watch`) to:

- `gateway.networking.k8s.io`: gatewayclasses, gateways, httproutes, referencegrants
- `gateway.envoyproxy.io`: backends, backendtrafficpolicies, clienttrafficpolicies,
  envoyextensionpolicies, envoypatchpolicies, envoyproxies, httproutefilters,
  securitypolicies

Viewers and developers inherit this access through `view`; admins already have it
via `cluster-admin`. No write rules are added — HTTPRoutes and policies are managed
by operators/charts, consistent with how Ingress exposure is handled today. This
follows the exact pattern already used to expose `v2.edp.epam.com` / `edp.epam.com`
CRs, and stays consistent with the KubeRocketCI platform auth model
(https://docs.kuberocketci.io/docs/operator-guide/auth/platform-auth-model).

Jira: EPMDEDP-17178

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

1. Chart render — the aggregated view role includes the new rules:

       cd deploy-templates
       helm dependency build
       helm template edp-install . -n edp-delivery-vpi-dev \
         --show-only templates/rbac/role_edp_aggregate_view.yaml

   The `edp-aggregate-view-<namespace>` ClusterRole renders with
   `aggregate-to-view: "true"` and the new `gateway.networking.k8s.io` +
   `gateway.envoyproxy.io` read rules.

2. Access check before the change (impersonating the viewer group) — confirms the
   gap this PR closes:

       NS=edp-delivery-vpi-dev
       for r in httproutes.gateway.networking.k8s.io gateways.gateway.networking.k8s.io \
                securitypolicies.gatewaypolicies.gateway.envoyproxy.io; do
         kubectl auth can-i list "$r" --as-group="$NS-oidc-viewers" --as=qa -n $NS
       done

   Result: viewer -> `no` for all Gateway resources, while `$NS-oidc-admins` -> `yes`
   (cluster-admin).

3. Post-deploy validation (AC4, after this merges and the role syncs to a cluster):
   the same `kubectl auth can-i` for the viewer group returns `yes` for the
   namespaced Gateway resources, and theking view
   (Gateways / HTTPRoutes / Policies) renders for viewers and developers.
   (gatewayclasses is cluster-scoped, so it is intentionally not granted through the
   namespaced tenant binding.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A, no doc change; aligned with the existing platform auth-model docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A for RBAC templates;
validated via helm render + kubectl auth
- [ ] New and existing unit tests pass locally with my changes — N/A (no unit tests for RBAC templates); helm
template renders clean
- [x] Pull Request contains one commit. I squash my commits.


## Additional context

- Read-only by design: developers inherit read via `view` and do not get write on
  Gateway resources, mirroring how Ingress is treated (developers have no write on
  `networking.k8s.io/ingresses`; those objects are operator/chart-managed).
- admin is unchanged: `cluster-admin` already covers every resource, so — exactly
  like Ingress — Gateway resources are not enumerated explicitly for admins.
- Pattern: standard resources (incl. ingn `view`; CRDs
  (KRCI CRs, and now Gateway API / Envoy Gateway) are added to `edp-aggregate-view`.
- Only `deploy-templates/templates/rbac/ changed; no
  Chart.yaml version bump (consistent with recent template-only changes).