### PR TITLE
EPMDEDP-17248: chore: Drop the edp-tekton pruner override

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -54,7 +54,6 @@ A Helm chart for KubeRocketCI Platform
 | edp-tekton.pipelines.imagePullSecrets | list | `[]` | List of image pull secrets used by the Tekton ServiceAccount for pulling images from private registries. Example: imagePullSecrets:   - name: regcred |
 | edp-tekton.pipelines.podTemplate | list | `[]` | This section allows to determine on which nodes to run tekton pipelines |
 | edp-tekton.tekton-cache.enabled | bool | `true` |  |
-| edp-tekton.tekton.pruner.create | bool | `true` |  |
 | externalSecrets.enabled | bool | `false` | Configure External Secrets for KubeRocketCI platform. Deploy SecretStore. Default: false |
 | externalSecrets.manageEDPInstallSecrets | bool | `true` | Create necessary secrets for KubeRocketCI installation, using External Secret Operator |
 | externalSecrets.manageEDPInstallSecretsName | string | `"/edp/deploy-secrets"` | Value name in AWS ParameterStore or AWS SecretsManager. Used when manageEDPInstallSecrets is true |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -440,12 +440,6 @@ edp-tekton:
     # imagePullSecrets: []
     # - name: regcred
 
-  tekton:
-    pruner:
-      create: true
-      # -- List of ImagePullSecrets to be used by the pruner CronJob
-      # imagePullSecrets: []
-
   interceptor:
     # -- Deploy KubeRocketCI interceptor as a part of pipeline library when true. Default: true
     enabled: true


### PR DESCRIPTION
The pruner CronJob has been removed from the edp-tekton chart now that Tekton Results owns retention and cleanup of completed PipelineRuns, so the umbrella chart no longer has a tekton.pruner key to override.

The override only restated the sub-chart default, so this is a no-op against the currently released edp-tekton chart and simply keeps the umbrella values aligned with the upcoming one.

